### PR TITLE
Add custom Getter for secret keys + Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Signing HTTP Messages Middleware base on [HTTP Signatures](https://tools.ietf.org/html/draft-cavage-http-signatures).
 
-## Example
+## Example 1. Secret keys from map
 ``` go
 
 package main
@@ -50,5 +50,47 @@ func main() {
 
 	r.Run(":8080")
 }
+
+```
+
+## Example 2. Secret keys from custom Getter
+``` go
+
+package main
+
+import (
+    "github.com/gin-contrib/httpsign"
+	"github.com/gin-contrib/httpsign/crypto"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+
+	secrets := httpsign.Secrets{
+		Get: func(id httpsign.KeyID) (*httpsign.Secret, bool) {
+			// Retrieve SecretKey from DB
+			// Set secret struct and return
+			secret := &httpsign.Secret{
+				Key:       "12345",
+				Algorithm: &crypto.HmacSha512{},
+			}
+			return secret, true
+		},
+	}
+
+	// Init server
+	r := gin.Default()
+
+	//Create middleware with default rule. Could modify by parse Option func
+	auth := httpsign.NewAuthenticator(secrets)
+
+	r.Use(auth.Authenticated())
+	r.GET("/a", func(context *gin.Context) {})
+	r.POST("/b", func(context *gin.Context) {})
+	r.POST("/c", func(context *gin.Context) {})
+
+	r.Run(":8080")
+}
+
 
 ```

--- a/authenticator.go
+++ b/authenticator.go
@@ -127,7 +127,13 @@ func (a *Authenticator) isValidHeader(headers []string) bool {
 }
 
 func (a *Authenticator) getSecret(keyID KeyID, algorithm string) (*Secret, error) {
-	secret, ok := a.secrets[keyID]
+	var secret *Secret
+	var ok bool
+	if a.secrets.Get != nil {
+		secret, ok = a.secrets.Get(keyID)
+	} else {
+		secret, ok = a.secrets.Keys[keyID]
+	}
 	if !ok {
 		return nil, ErrInvalidKeyID
 	}

--- a/secret.go
+++ b/secret.go
@@ -11,5 +11,11 @@ type Secret struct {
 	Algorithm crypto.Crypto
 }
 
+// Secrets getter function signature
+type Handler = func(id KeyID) (*Secret, bool)
+
 // Secrets map with keyID and secret
-type Secrets map[KeyID]*Secret
+type Secrets struct {
+	Keys map[KeyID]*Secret
+	Get  Handler
+}


### PR DESCRIPTION
Add support for customer Get function to retrieve a secret key from an external source (e.g. DB, File etc). 
+ test for authenticatorGetSecret()