### PR TITLE
Custom Getter for secret keys, parser skip spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Signing HTTP Messages Middleware base on [HTTP Signatures](https://tools.ietf.org/html/draft-cavage-http-signatures).
 
-## Example
+## Example 1. Secret keys from map
 ``` go
 
 package main
@@ -50,5 +50,47 @@ func main() {
 
 	r.Run(":8080")
 }
+
+```
+
+## Example 2. Secret keys from custom Getter
+``` go
+
+package main
+
+import (
+    "github.com/gin-contrib/httpsign"
+	"github.com/gin-contrib/httpsign/crypto"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+
+	secrets := httpsign.Secrets{
+		Get: func(id httpsign.KeyID) (*httpsign.Secret, bool) {
+			// Retrieve SecretKey from DB
+			// Set secret struct and return
+			secret := &httpsign.Secret{
+				Key:       "12345",
+				Algorithm: &crypto.HmacSha512{},
+			}
+			return secret, true
+		},
+	}
+
+	// Init server
+	r := gin.Default()
+
+	//Create middleware with default rule. Could modify by parse Option func
+	auth := httpsign.NewAuthenticator(secrets)
+
+	r.Use(auth.Authenticated())
+	r.GET("/a", func(context *gin.Context) {})
+	r.POST("/b", func(context *gin.Context) {})
+	r.POST("/c", func(context *gin.Context) {})
+
+	r.Run(":8080")
+}
+
 
 ```

--- a/authenticator.go
+++ b/authenticator.go
@@ -127,7 +127,13 @@ func (a *Authenticator) isValidHeader(headers []string) bool {
 }
 
 func (a *Authenticator) getSecret(keyID KeyID, algorithm string) (*Secret, error) {
-	secret, ok := a.secrets[keyID]
+	var secret *Secret
+	var ok bool
+	if a.secrets.Get != nil {
+		secret, ok = a.secrets.Get(keyID)
+	} else {
+		secret, ok = a.secrets.Keys[keyID]
+	}
 	if !ok {
 		return nil, ErrInvalidKeyID
 	}

--- a/parser.go
+++ b/parser.go
@@ -58,7 +58,7 @@ func (p *parser) nextParam() (string, string, error) {
 			if !keyParsed {
 				return "", "", ErrMisingEqualCharacter
 			}
-			if p.peekChar() != ',' && p.peekChar() != 0 {
+			if p.peekChar() != ',' && p.peekChar() != 0 && p.peekChar() != ' ' {
 				if err := val.WriteByte(p.ch); err != nil {
 					return "", "", err
 				}
@@ -69,6 +69,9 @@ func (p *parser) nextParam() (string, string, error) {
 		case '=':
 			if !keyParsed {
 				p.readChar()
+				for p.ch == ' ' {
+					p.readChar()
+				}
 				if p.ch != '"' {
 					return "", "", ErrMisingDoubleQuote
 				}
@@ -81,10 +84,14 @@ func (p *parser) nextParam() (string, string, error) {
 			p.readChar()
 		default:
 			if !keyParsed {
+				if p.ch == ' ' {
+					p.readChar()
+					continue
+				}
 				if err := key.WriteByte(p.ch); err != nil {
 					return "", "", err
 				}
-			} else {
+			} else if !valParsed {
 				if err := val.WriteByte(p.ch); err != nil {
 					return "", "", err
 				}

--- a/parser_test.go
+++ b/parser_test.go
@@ -51,6 +51,17 @@ func TestParser(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name:  `correct test with spaces`,
+			input: `   keyId =  "rsa-key-1" , algorithm = "rsa-sha256",headers ="(request-target) host date digest",  signature=  "70AaN3BDO0XC9QbtgksgCy2jJvmOvshq8VmjSthdXC+sgcgrKrl9WME4DbZv4W7UZKElvCemhDLHQ1Nln9GMkQ=="   `,
+			params: map[string]string{
+				"keyId":     "rsa-key-1",
+				"algorithm": "rsa-sha256",
+				"headers":   "(request-target) host date digest",
+				"signature": "70AaN3BDO0XC9QbtgksgCy2jJvmOvshq8VmjSthdXC+sgcgrKrl9WME4DbZv4W7UZKElvCemhDLHQ1Nln9GMkQ==",
+			},
+			err: nil,
+		},
 	}
 	for _, tc := range tests {
 		p := newParser(tc.input)

--- a/secret.go
+++ b/secret.go
@@ -11,5 +11,11 @@ type Secret struct {
 	Algorithm crypto.Crypto
 }
 
+// Secrets getter function signature
+type Handler = func(id KeyID) (*Secret, bool)
+
 // Secrets map with keyID and secret
-type Secrets map[KeyID]*Secret
+type Secrets struct {
+	Keys map[KeyID]*Secret
+	Get  Handler
+}

--- a/validator/datevalidate.go
+++ b/validator/datevalidate.go
@@ -9,7 +9,7 @@ import (
 const maxTimeGap = 30 * time.Second // 30 secs
 
 //ErrDateNotInRange error when date not in aceptable range
-var ErrDateNotInRange = errors.New("Date submit is not in aceptable range")
+var ErrDateNotInRange = errors.New("submitted Date header is not in acceptable range")
 
 // DateValidator checking validate by time range
 type DateValidator struct {


### PR DESCRIPTION
1. Added custom "Get" function to retrieve secret key(s) from external storage (if you have a lot of keys).
2. Improve parser to skip spaces between "=" & "," chars. Now it's possible to write ` keyId =  "rsa-key-1", ...` and you will not get " keyId " key (with spaces).